### PR TITLE
Add arrowheads to birth-death lines

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css">
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+  <script src="https://unpkg.com/leaflet-arrowheads@1.3.1/src/leaflet-arrowheads.js"></script>
   <style>
     html, body, #map { height: 100%; margin: 0; }
     .sidebar {
@@ -340,6 +341,9 @@
           return p.era === era && (!y || (y >= start && y <= end));
         });
         layer.addData({ type: "FeatureCollection", features: feats });
+        layer.eachLayer(l => {
+          if (l.arrowheads) l.arrowheads({ frequency: 'end', size: '15px' });
+        });
       });
     };
     yearFilters.push(render);


### PR DESCRIPTION
## Summary
- load leaflet-arrowheads plugin
- draw arrowheads for birth→death polylines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898da5fb0b883339798a94192c3ccc4