### PR TITLE
Add responsive sidebar toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,10 +14,23 @@
   <script src="https://unpkg.com/leaflet-arrowheads@1.3.1/src/leaflet-arrowheads.js"></script>
   <style>
     html, body, #map { height: 100%; margin: 0; }
+    #navToggle {
+      position: absolute; z-index: 1100; top: 10px; left: 10px;
+      background: white; border: none; padding: 6px 10px;
+      border-radius: 8px; box-shadow: 0 6px 18px rgba(0,0,0,.15);
+      font-size: 20px; cursor: pointer;
+    }
     .sidebar {
       position: absolute; z-index: 1000; top: 10px; left: 10px;
       background: white; padding: 10px 12px; border-radius: 8px;
       box-shadow: 0 6px 18px rgba(0,0,0,.15); max-width: 360px; font: 14px/1.3 system-ui, sans-serif;
+    }
+    @media (max-width: 767px) {
+      .sidebar { transform: translateX(-110%); transition: transform .3s ease; }
+      .sidebar.sidebar--open { transform: translateX(0); }
+    }
+    @media (min-width: 768px) {
+      #navToggle { display: none; }
     }
     .legend { margin-top: 8px; font-size: 13px; }
     .legend div { margin: 4px 0; display:flex; align-items:center; gap:6px; }
@@ -29,7 +42,8 @@
 </head>
 <body>
   <div id="map"></div>
-  <div class="sidebar">
+  <button id="navToggle" aria-controls="sidebar" aria-expanded="false">☰</button>
+  <div id="sidebar" class="sidebar">
     <div><input id="searchInput" type="text" placeholder="Search…" style="width:100%" /></div>
     <div style="margin-top:6px;">
       <label>Years: <span id="yearLabel"></span></label>
@@ -168,6 +182,12 @@
   }
 
   const searchInputEl = document.getElementById('searchInput');
+  const navToggle = document.getElementById('navToggle');
+  const sidebarEl = document.getElementById('sidebar');
+  navToggle.addEventListener('click', () => {
+    const open = sidebarEl.classList.toggle('sidebar--open');
+    navToggle.setAttribute('aria-expanded', open);
+  });
   function doSearch(q) {
     q = q.trim().toLowerCase();
     if (!q) return;


### PR DESCRIPTION
## Summary
- add menu button for small screens and responsive sidebar container
- implement CSS media queries and JavaScript toggle to show/hide sidebar

## Testing
- `npm test` *(fails: enoent package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898dd83c5548333b97888d28d543863