### PR TITLE
Initialize Leaflet map in App component

### DIFF
--- a/family-history-map/src/App.jsx
+++ b/family-history-map/src/App.jsx
@@ -1,35 +1,15 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useEffect } from 'react'
+import L from 'leaflet'
 
 function App() {
-  const [count, setCount] = useState(0)
+  useEffect(() => {
+    const map = L.map('map').setView([0, 0], 2)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors',
+    }).addTo(map)
+  }, [])
 
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <div id="map"></div>
 }
 
 export default App

--- a/family-history-map/src/main.jsx
+++ b/family-history-map/src/main.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- Remove Vite scaffolding and render Leaflet map in `App.jsx`
- Drop unused stylesheet import so map can fill viewport

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f9e19b348333a75c7edddbbb8601