### PR TITLE
Add interactive map sidebar and controls

### DIFF
--- a/family-history-map/src/App.jsx
+++ b/family-history-map/src/App.jsx
@@ -1,15 +1,10 @@
-import { useEffect } from 'react'
-import L from 'leaflet'
+import Sidebar from './components/Sidebar'
+import { MapProvider } from './MapContext'
 
-function App() {
-  useEffect(() => {
-    const map = L.map('map').setView([0, 0], 2)
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; OpenStreetMap contributors',
-    }).addTo(map)
-  }, [])
-
-  return <div id="map"></div>
+export default function App() {
+  return (
+    <MapProvider>
+      <Sidebar />
+    </MapProvider>
+  )
 }
-
-export default App

--- a/family-history-map/src/MapContext.jsx
+++ b/family-history-map/src/MapContext.jsx
@@ -1,0 +1,286 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+
+const MapContext = createContext(null)
+
+function popupTable(props) {
+  return `<table>${Object.entries(props)
+    .map(([k, v]) => `<tr><th>${k}</th><td>${v}</td></tr>`)
+    .join('')}</table>`
+}
+
+export function MapProvider({ children }) {
+  const mapRef = useRef(null)
+  const overlaysRef = useRef({})
+  const searchIndexRef = useRef([])
+  const yearFiltersRef = useRef([])
+
+  const [yearStart, setYearStart] = useState(1600)
+  const [yearEnd, setYearEnd] = useState(2020)
+  const [eras, setEras] = useState([])
+  const [activeLayers, setActiveLayers] = useState({})
+
+  const eraColors = {
+    'Early Republic': '#d9534f',
+    'Gilded Age': '#f0ad4e',
+    'Colonial Era': '#5cb85c',
+    'Civil War & Reconstruction': '#5bc0de',
+    'Progressive Era & WWI': '#337ab7',
+    'Roaring 20s & Great Depression': '#8e44ad',
+  }
+
+  useEffect(() => {
+    mapRef.current = L.map('map').setView([0, 0], 2)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors',
+    }).addTo(mapRef.current)
+
+    const loadJson = url => fetch(url).then(r => r.json())
+
+    const addOverlay = (layer, name, checked = true) => {
+      overlaysRef.current[name] = layer
+      setActiveLayers(prev => ({ ...prev, [name]: checked }))
+      if (checked) mapRef.current.addLayer(layer)
+    }
+
+    // People
+    loadJson('/data/people.geojson').then(data => {
+      const layer = L.geoJSON([], {
+        pointToLayer: (f, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 6,
+            color: '#0A84FF',
+            weight: 1,
+            fillOpacity: 0.9,
+          }),
+        onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
+      })
+      const render = (start, end) => {
+        layer.clearLayers()
+        const feats = (data.features || []).filter(f => {
+          const y = f.properties?.birth_year || f.properties?.death_year
+          return !y || (y >= start && y <= end)
+        })
+        layer.addData({ type: 'FeatureCollection', features: feats })
+      }
+      yearFiltersRef.current.push(render)
+      render(yearStart, yearEnd)
+      addOverlay(layer, 'People', true)
+      ;(data.features || []).forEach(f =>
+        searchIndexRef.current.push({ feature: f, field: 'people' }),
+      )
+    })
+
+    // Places
+    loadJson('/data/places.geojson').then(data => {
+      const layer = L.geoJSON(data, {
+        pointToLayer: (f, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 6,
+            color: '#2ed573',
+            weight: 1,
+            fillOpacity: 0.6,
+          }),
+        style: () => ({
+          color: '#2ed573',
+          weight: 2,
+          opacity: 0.8,
+          fillOpacity: 0.2,
+        }),
+        onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
+      })
+      addOverlay(layer, 'Places', true)
+      ;(data.features || []).forEach(f =>
+        searchIndexRef.current.push({ feature: f, field: 'places' }),
+      )
+    })
+
+    // Events
+    loadJson('/data/events.geojson').then(data => {
+      const layer = L.geoJSON([], {
+        pointToLayer: (f, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 6,
+            color: '#b30000',
+            weight: 1,
+            fillOpacity: 0.9,
+          }),
+        style: () => ({ color: '#ff6b6b', weight: 2, opacity: 0.9 }),
+        onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
+      })
+      const render = (start, end) => {
+        layer.clearLayers()
+        const feats = (data.features || []).filter(f => {
+          const y = f.properties?.event_year
+          return !y || (y >= start && y <= end)
+        })
+        layer.addData({ type: 'FeatureCollection', features: feats })
+      }
+      yearFiltersRef.current.push(render)
+      render(yearStart, yearEnd)
+      addOverlay(layer, 'Events', false)
+      ;(data.features || []).forEach(f =>
+        searchIndexRef.current.push({ feature: f, field: 'events' }),
+      )
+    })
+
+    // Birth Points
+    loadJson('/data/birth_location_points.geojson').then(data => {
+      const layer = L.geoJSON([], {
+        pointToLayer: (f, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 6,
+            color: '#1f77ff',
+            weight: 1,
+            fillOpacity: 0.9,
+          }),
+        onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
+      })
+      const render = (start, end) => {
+        layer.clearLayers()
+        const feats = (data.features || []).filter(f => {
+          const y = f.properties?.birth_year
+          return !y || (y >= start && y <= end)
+        })
+        layer.addData({ type: 'FeatureCollection', features: feats })
+      }
+      yearFiltersRef.current.push(render)
+      render(yearStart, yearEnd)
+      addOverlay(layer, 'Birth Points', true)
+      ;(data.features || []).forEach(f =>
+        searchIndexRef.current.push({ feature: f, field: 'births' }),
+      )
+    })
+
+    // Death Points
+    loadJson('/data/death_location_points.geojson').then(data => {
+      const layer = L.geoJSON([], {
+        pointToLayer: (f, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 6,
+            color: '#e43f3f',
+            weight: 1,
+            fillOpacity: 0.9,
+          }),
+        onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
+      })
+      const render = (start, end) => {
+        layer.clearLayers()
+        const feats = (data.features || []).filter(f => {
+          const y = f.properties?.death_year
+          return !y || (y >= start && y <= end)
+        })
+        layer.addData({ type: 'FeatureCollection', features: feats })
+      }
+      yearFiltersRef.current.push(render)
+      render(yearStart, yearEnd)
+      addOverlay(layer, 'Death Points', true)
+      ;(data.features || []).forEach(f =>
+        searchIndexRef.current.push({ feature: f, field: 'deaths' }),
+      )
+    })
+
+    // Era lines
+    loadJson('/data/birth_to_death_lines_eras.geojson').then(data => {
+      const eras = Array.from(
+        new Set((data.features || []).map(f => f.properties?.era).filter(Boolean)),
+      ).sort()
+      setEras(eras)
+      const lineLayers = {}
+      eras.forEach(era => {
+        const sub = L.geoJSON([], {
+          style: () => ({
+            color: eraColors[era] || '#000',
+            weight: 2.5,
+            opacity: 0.95,
+          }),
+          onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
+        })
+        lineLayers[era] = sub
+        addOverlay(sub, `Lines: ${era}`, true)
+      })
+      const render = (start, end) => {
+        eras.forEach(era => {
+          const layer = lineLayers[era]
+          layer.clearLayers()
+          const feats = (data.features || []).filter(f => {
+            const p = f.properties || {}
+            const y = p.birth_year || p.death_year
+            return p.era === era && (!y || (y >= start && y <= end))
+          })
+          layer.addData({ type: 'FeatureCollection', features: feats })
+        })
+      }
+      yearFiltersRef.current.push(render)
+      render(yearStart, yearEnd)
+      ;(data.features || []).forEach(f =>
+        searchIndexRef.current.push({ feature: f, field: 'lines' }),
+      )
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    yearFiltersRef.current.forEach(fn => fn(yearStart, yearEnd))
+  }, [yearStart, yearEnd])
+
+  const setLayerVisible = (name, visible) => {
+    const layer = overlaysRef.current[name]
+    if (!layer) return
+    if (visible) mapRef.current.addLayer(layer)
+    else mapRef.current.removeLayer(layer)
+    setActiveLayers(prev => ({ ...prev, [name]: visible }))
+  }
+
+  const search = q => {
+    q = q.trim().toLowerCase()
+    if (!q) return
+    const match = searchIndexRef.current.find(({ feature }) =>
+      Object.values(feature.properties || {}).some(v =>
+        String(v).toLowerCase().includes(q),
+      ),
+    )
+    if (match) {
+      const tmp = L.geoJSON(match.feature)
+      tmp.bindPopup(popupTable(match.feature.properties || {}))
+      tmp.addTo(mapRef.current)
+      mapRef.current.fitBounds(tmp.getBounds().pad(0.25))
+      tmp.openPopup()
+      setTimeout(() => mapRef.current.removeLayer(tmp), 5000)
+    }
+  }
+
+  const applyPreset = ({ layers, range }) => {
+    Object.keys(overlaysRef.current).forEach(name => {
+      setLayerVisible(name, layers.includes(name))
+    })
+    if (range) {
+      setYearStart(range[0])
+      setYearEnd(range[1])
+    }
+  }
+
+  const value = {
+    activeLayers,
+    setLayerVisible,
+    yearStart,
+    yearEnd,
+    setYearStart,
+    setYearEnd,
+    eras,
+    eraColors,
+    search,
+    applyPreset,
+  }
+
+  return (
+    <MapContext.Provider value={value}>
+      <div id="map"></div>
+      {children}
+    </MapContext.Provider>
+  )
+}
+
+export const useMapContext = () => useContext(MapContext)

--- a/family-history-map/src/components/EraChips.jsx
+++ b/family-history-map/src/components/EraChips.jsx
@@ -1,0 +1,25 @@
+import { useMapContext } from '../MapContext'
+
+export default function EraChips() {
+  const { eras, eraColors, activeLayers, setLayerVisible } = useMapContext()
+  if (!eras.length) return null
+  return (
+    <div id="eraChips" style={{ marginTop: 8 }}>
+      {eras.map(era => {
+        const name = `Lines: ${era}`
+        const active = !!activeLayers[name]
+        return (
+          <span
+            key={era}
+            className={`chip ${active ? 'active' : ''}`}
+            data-layer={name}
+            style={{ background: eraColors[era] }}
+            onClick={() => setLayerVisible(name, !active)}
+          >
+            {era}
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/family-history-map/src/components/LayerToggles.jsx
+++ b/family-history-map/src/components/LayerToggles.jsx
@@ -1,0 +1,22 @@
+import { useMapContext } from '../MapContext'
+
+const LAYERS = ['People', 'Places', 'Events', 'Birth Points', 'Death Points']
+
+export default function LayerToggles() {
+  const { activeLayers, setLayerVisible } = useMapContext()
+  return (
+    <div style={{ marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+      {LAYERS.map(name => (
+        <label key={name} style={{ whiteSpace: 'nowrap' }}>
+          <input
+            type="checkbox"
+            data-layer={name}
+            checked={!!activeLayers[name]}
+            onChange={e => setLayerVisible(name, e.target.checked)}
+          />{' '}
+          {name}
+        </label>
+      ))}
+    </div>
+  )
+}

--- a/family-history-map/src/components/Search.jsx
+++ b/family-history-map/src/components/Search.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { useMapContext } from '../MapContext'
+
+const PRESETS = [
+  {
+    label: 'All',
+    range: [1600, 2020],
+    layers: ['People', 'Places', 'Events', 'Birth Points', 'Death Points'],
+  },
+  {
+    label: 'People 1800-1900',
+    range: [1800, 1900],
+    layers: ['People'],
+  },
+]
+
+export default function Search() {
+  const [query, setQuery] = useState('')
+  const { search, applyPreset } = useMapContext()
+
+  const doSearch = () => {
+    search(query)
+  }
+
+  return (
+    <div>
+      <input
+        id="searchInput"
+        type="text"
+        placeholder="Search…"
+        style={{ width: '100%' }}
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            doSearch()
+          }
+        }}
+      />
+      <div
+        id="presets"
+        style={{ marginTop: 8, display: 'flex', gap: 4, flexWrap: 'wrap' }}
+      >
+        {PRESETS.map(p => (
+          <button key={p.label} onClick={() => applyPreset(p)}>
+            {p.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/family-history-map/src/components/Sidebar.jsx
+++ b/family-history-map/src/components/Sidebar.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import LayerToggles from './LayerToggles'
+import YearRange from './YearRange'
+import Search from './Search'
+import EraChips from './EraChips'
+
+export default function Sidebar() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button
+        id="navToggle"
+        aria-controls="sidebar"
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+      >
+        ☰
+      </button>
+      <div id="sidebar" className={`sidebar ${open ? 'sidebar--open' : ''}`}>
+        <Search />
+        <YearRange />
+        <LayerToggles />
+        <EraChips />
+      </div>
+    </>
+  )
+}

--- a/family-history-map/src/components/YearRange.jsx
+++ b/family-history-map/src/components/YearRange.jsx
@@ -1,0 +1,32 @@
+import { useMapContext } from '../MapContext'
+
+export default function YearRange() {
+  const { yearStart, yearEnd, setYearStart, setYearEnd } = useMapContext()
+  return (
+    <div style={{ marginTop: 6 }}>
+      <label>
+        Years: <span>{yearStart} - {yearEnd}</span>
+      </label>
+      <div style={{ display: 'flex', gap: 4 }}>
+        <input
+          type="range"
+          id="yearStart"
+          min="1600"
+          max="2020"
+          value={yearStart}
+          onChange={e => setYearStart(+e.target.value)}
+          style={{ flex: 1 }}
+        />
+        <input
+          type="range"
+          id="yearEnd"
+          min="1600"
+          max="2020"
+          value={yearEnd}
+          onChange={e => setYearEnd(+e.target.value)}
+          style={{ flex: 1 }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/family-history-map/src/index.css
+++ b/family-history-map/src/index.css
@@ -1,68 +1,60 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
+html, body, #root, #map {
+  height: 100%;
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
+#navToggle {
+  position: absolute;
+  z-index: 1100;
+  top: 10px;
+  left: 10px;
+  background: white;
+  border: none;
+  padding: 6px 10px;
   border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, .15);
+  font-size: 20px;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+.sidebar {
+  position: absolute;
+  z-index: 1000;
+  top: 10px;
+  left: 10px;
+  background: white;
+  padding: 10px 12px;
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, .15);
+  max-width: 360px;
+  font: 14px/1.3 system-ui, sans-serif;
+}
+
+@media (max-width: 767px) {
+  .sidebar {
+    transform: translateX(-110%);
+    transition: transform .3s ease;
   }
-  a:hover {
-    color: #747bff;
+  .sidebar.sidebar--open {
+    transform: translateX(0);
   }
-  button {
-    background-color: #f9f9f9;
+}
+
+@media (min-width: 768px) {
+  #navToggle {
+    display: none;
   }
+}
+
+.chip {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 12px;
+  background: #eee;
+  margin: 2px;
+  cursor: pointer;
+}
+
+.chip.active {
+  background: #ddd;
 }

--- a/family-history-map/src/main.jsx
+++ b/family-history-map/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- Add MapContext that loads geojson layers, manages visibility, year filtering, and feature search.
- Implement Sidebar with nav toggle, layer checkboxes, year sliders, search with presets, and era chips.
- Style map layout and sidebar for responsive display.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899089e4e54833399a8f987a7b27769