### PR TITLE
refactor: bundle Leaflet assets via npm

### DIFF
--- a/family-history-map/index.html
+++ b/family-history-map/index.html
@@ -4,14 +4,6 @@
     <meta charset="utf-8" />
     <title>Family History Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- Leaflet -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
-    <!-- MarkerCluster -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
-    <script src="https://unpkg.com/leaflet-arrowheads@1.3.1/src/leaflet-arrowheads.js"></script>
     <style>
       html, body, #map { height: 100%; margin: 0; }
       #navToggle {

--- a/family-history-map/src/App.jsx
+++ b/family-history-map/src/App.jsx
@@ -1,5 +1,10 @@
 import { useEffect } from 'react'
 import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import 'leaflet.markercluster/dist/MarkerCluster.css'
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
+import 'leaflet.markercluster'
+import 'leaflet-arrowheads'
 
 function App() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove Leaflet CDN tags from index.html
- import Leaflet and plugins with their CSS in App.jsx so Vite bundles them

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689908a669a88333b4bc0de2c341fcd0