### PR TITLE
Add arrowheads to era lines

### DIFF
--- a/family-history-map/src/MapContext.jsx
+++ b/family-history-map/src/MapContext.jsx
@@ -2,6 +2,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
+import 'leaflet-arrowheads'
 
 const MapContext = createContext(null)
 
@@ -197,6 +198,7 @@ export function MapProvider({ children }) {
             opacity: 0.95,
           }),
           onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
+          arrowheads: { size: '8px', frequency: 'endonly', fill: true },
         })
         lineLayers[era] = sub
         addOverlay(sub, `Lines: ${era}`, true)


### PR DESCRIPTION
## Summary
- show directional flow on era line overlays using `leaflet-arrowheads`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68991254e6c8833384636643a49e0558