### PR TITLE
Load Leaflet libraries via npm

### DIFF
--- a/family-history-map/index.html
+++ b/family-history-map/index.html
@@ -4,14 +4,6 @@
     <meta charset="utf-8" />
     <title>Family History Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- Leaflet -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
-    <!-- MarkerCluster -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
-    <script src="https://unpkg.com/leaflet-arrowheads@1.3.1/src/leaflet-arrowheads.js"></script>
     <style>
       html, body, #map { height: 100%; margin: 0; }
       #navToggle {

--- a/family-history-map/src/MapContext.jsx
+++ b/family-history-map/src/MapContext.jsx
@@ -2,6 +2,9 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
+import 'leaflet.markercluster'
+import 'leaflet.markercluster/dist/MarkerCluster.css'
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 import 'leaflet-arrowheads'
 
 const MapContext = createContext(null)


### PR DESCRIPTION
## Summary
- Remove CDN script and link tags for Leaflet, MarkerCluster, and Arrowheads from `family-history-map/index.html`
- Import Leaflet plugins and styles directly in `MapContext.jsx`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68991734fa008333b46dc22944b886f8