### PR TITLE
Add selectable basemap layers

### DIFF
--- a/family-history-map/README.md
+++ b/family-history-map/README.md
@@ -1,12 +1,28 @@
-# React + Vite
+# Family History Map
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a React + Leaflet application for exploring family history data.
 
-Currently, two official plugins are available:
+## Basemap Layers
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+The map includes several selectable basemap layers:
 
-## Expanding the ESLint configuration
+- OpenStreetMap
+- OpenTopoMap
+- Stamen Toner
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Use the basemap selector in the sidebar to switch between these layers at runtime.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Run the linter with:
+
+```bash
+npm run lint
+```

--- a/family-history-map/src/components/BasemapSelector.jsx
+++ b/family-history-map/src/components/BasemapSelector.jsx
@@ -1,0 +1,24 @@
+import { useMapContext } from '../MapContext'
+
+export default function BasemapSelector() {
+  const { basemap, setBasemap, basemapOptions } = useMapContext()
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <label>
+        Basemap:
+        <select
+          value={basemap}
+          onChange={e => setBasemap(e.target.value)}
+          style={{ marginLeft: 4 }}
+        >
+          {basemapOptions.map(name => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}

--- a/family-history-map/src/components/Sidebar.jsx
+++ b/family-history-map/src/components/Sidebar.jsx
@@ -3,6 +3,7 @@ import LayerToggles from './LayerToggles'
 import YearRange from './YearRange'
 import Search from './Search'
 import EraChips from './EraChips'
+import BasemapSelector from './BasemapSelector'
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false)
@@ -18,6 +19,7 @@ export default function Sidebar() {
       </button>
       <div id="sidebar" className={`sidebar ${open ? 'sidebar--open' : ''}`}>
         <Search />
+        <BasemapSelector />
         <YearRange />
         <LayerToggles />
         <EraChips />


### PR DESCRIPTION
## Summary
- allow choosing from several basemap layers
- expose basemap selection via context and sidebar control
- document available basemaps and usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68991b711c5c833380ed77827e0aa751