### PR TITLE
Cluster map point layers

### DIFF
--- a/family-history-map/src/MapContext.jsx
+++ b/family-history-map/src/MapContext.jsx
@@ -92,7 +92,9 @@ export function MapProvider({ children }) {
       }
       yearFiltersRef.current.push(render)
       render(yearStart, yearEnd)
-      addOverlay(layer, 'People', true)
+      const cluster = L.markerClusterGroup({ spiderfyOnMaxZoom: true })
+      cluster.addLayer(layer)
+      addOverlay(cluster, 'People', true)
       ;(data.features || []).forEach(f =>
         searchIndexRef.current.push({ feature: f, field: 'people' }),
       )
@@ -116,7 +118,9 @@ export function MapProvider({ children }) {
         }),
         onEachFeature: (f, l) => l.bindPopup(popupTable(f.properties || {})),
       })
-      addOverlay(layer, 'Places', true)
+      const cluster = L.markerClusterGroup({ spiderfyOnMaxZoom: true })
+      cluster.addLayer(layer)
+      addOverlay(cluster, 'Places', true)
       ;(data.features || []).forEach(f =>
         searchIndexRef.current.push({ feature: f, field: 'places' }),
       )
@@ -145,7 +149,9 @@ export function MapProvider({ children }) {
       }
       yearFiltersRef.current.push(render)
       render(yearStart, yearEnd)
-      addOverlay(layer, 'Events', false)
+      const cluster = L.markerClusterGroup({ spiderfyOnMaxZoom: true })
+      cluster.addLayer(layer)
+      addOverlay(cluster, 'Events', false)
       ;(data.features || []).forEach(f =>
         searchIndexRef.current.push({ feature: f, field: 'events' }),
       )
@@ -173,7 +179,9 @@ export function MapProvider({ children }) {
       }
       yearFiltersRef.current.push(render)
       render(yearStart, yearEnd)
-      addOverlay(layer, 'Birth Points', true)
+      const cluster = L.markerClusterGroup({ spiderfyOnMaxZoom: true })
+      cluster.addLayer(layer)
+      addOverlay(cluster, 'Birth Points', true)
       ;(data.features || []).forEach(f =>
         searchIndexRef.current.push({ feature: f, field: 'births' }),
       )
@@ -201,7 +209,9 @@ export function MapProvider({ children }) {
       }
       yearFiltersRef.current.push(render)
       render(yearStart, yearEnd)
-      addOverlay(layer, 'Death Points', true)
+      const cluster = L.markerClusterGroup({ spiderfyOnMaxZoom: true })
+      cluster.addLayer(layer)
+      addOverlay(cluster, 'Death Points', true)
       ;(data.features || []).forEach(f =>
         searchIndexRef.current.push({ feature: f, field: 'deaths' }),
       )


### PR DESCRIPTION
## Summary
- Wrap People, Places, Events, Birth Point, and Death Point layers in marker cluster groups to handle overlapping markers with spiderfying

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68991ee59e908333b93b197750ab6d27