### PR TITLE
Improve chip accessibility with contrasting active state

### DIFF
--- a/family-history-map/src/index.css
+++ b/family-history-map/src/index.css
@@ -63,14 +63,25 @@ html, body, #root, #map {
 }
 
 .chip {
-  display: inline-block;
-  padding: 2px 6px;
-  border-radius: 12px;
-  background: #eee;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 16px;
+  border: 1px solid #ccc;
+  background: #f9f9f9;
+  color: #333;
   margin: 2px;
   cursor: pointer;
 }
 
 .chip.active {
-  background: #ddd;
+  background: #005a9c;
+  border-color: #00447a;
+  color: #fff;
+}
+
+.chip.active::before {
+  content: "\2713";
+  font-size: 0.85em;
 }


### PR DESCRIPTION
## Summary
- Restyle chip controls with higher contrast and borders
- Highlight active chips in bold blue and include a checkmark indicator

## Testing
- `npm run lint`
- `node -e "function luminance(r,g,b){var a=[r,g,b].map(function(v){v/=255;return v<=0.03928? v/12.92:Math.pow((v+0.055)/1.055,2.4);});return a[0]*0.2126 + a[1]*0.7152 + a[2]*0.0722;} function contrast(rgb1,rgb2){var L1=luminance(rgb1[0],rgb1[1],rgb1[2])+0.05;var L2=luminance(rgb2[0],rgb2[1],rgb2[2])+0.05;return L1>L2?L1/L2:L2/L1;} function hexToRgb(hex){hex=hex.replace('#','');return [parseInt(hex.substr(0,2),16),parseInt(hex.substr(2,2),16),parseInt(hex.substr(4,2),16)];} console.log('contrast default', contrast(hexToRgb('#333333'), hexToRgb('#f9f9f9')).toFixed(2)); console.log('contrast active', contrast(hexToRgb('#ffffff'), hexToRgb('#005a9c')).toFixed(2));"`


------
https://chatgpt.com/codex/tasks/task_e_6899453a0af083338bc139e3aca981eb