### PR TITLE
Configure docs build and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Build and deploy site
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: family-history-map/package-lock.json
+
+      - name: Install dependencies and build
+        working-directory: family-history-map
+        run: |
+          npm ci
+          npm run build
+
+      - name: Commit docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          if [ -n "$(git status --porcelain docs)" ]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add docs
+            git commit -m "chore: build docs"
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:${GITHUB_REF_NAME}
+          else
+            echo "No changes to commit"
+          fi

--- a/family-history-map/vite.config.js
+++ b/family-history-map/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: "../docs",
+  },
 })


### PR DESCRIPTION
## Summary
- build family history map into the top-level `docs` directory for GitHub Pages
- add workflow to build the map and commit the generated `docs` on pushes to `main`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689950456b7c8333b7056c2f7c4aab40