### PR TITLE
Use relative base for Vite build

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,8 +7,8 @@
     <style>
       html, body, #map { height: 100%; margin: 0; }
     </style>
-    <script type="module" crossorigin src="/assets/index-Doogm_5c.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-C4ds6L9R.css">
+    <script type="module" crossorigin src="./assets/index-Doogm_5c.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-C4ds6L9R.css">
   </head>
   <body>
     <div id="root"></div>

--- a/family-history-map/vite.config.js
+++ b/family-history-map/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: "./",
   build: {
     outDir: "../docs",
   },


### PR DESCRIPTION
## Summary
- set Vite `base` to `./` so production assets use relative paths
- rebuild docs with new asset URLs

## Testing
- `cd family-history-map && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899556d81e08333bc381b11de77d21d